### PR TITLE
Remove focused panel heading outline, use focus-ring instead

### DIFF
--- a/src/vaadin-accordion.html
+++ b/src/vaadin-accordion.html
@@ -241,6 +241,7 @@ This program is available under Apache License Version 2.0, available at https:/
           idx = this._getAvailableIndex(idx, increment);
           if (idx >= 0) {
             this.items[idx].focus();
+            this.items[idx].setAttribute('focus-ring', '');
             event.preventDefault();
           }
         }

--- a/test/accordion.html
+++ b/test/accordion.html
@@ -120,6 +120,7 @@
           heading = getHeading(0);
           arrowDown(heading);
           expect(accordion.items[1].hasAttribute('focused')).to.be.true;
+          expect(accordion.items[1].hasAttribute('focus-ring')).to.be.true;
         });
 
         it('should move focus when event.key name does not include the Arrow prefix (IE)', () => {
@@ -134,6 +135,7 @@
           heading = getHeading(1);
           arrowUp(heading);
           expect(accordion.items[0].hasAttribute('focused')).to.be.true;
+          expect(accordion.items[0].hasAttribute('focus-ring')).to.be.true;
         });
 
         it('should move focus to first element on "home" keydown', () => {
@@ -141,6 +143,7 @@
           heading = getHeading(2);
           home(heading);
           expect(accordion.items[0].hasAttribute('focused')).to.be.true;
+          expect(accordion.items[0].hasAttribute('focus-ring')).to.be.true;
         });
 
         it('should move focus to second element if first is disabled on "home" keydown', () => {
@@ -155,6 +158,7 @@
           heading = getHeading(0);
           end(heading);
           expect(accordion.items[2].hasAttribute('focused')).to.be.true;
+          expect(accordion.items[2].hasAttribute('focus-ring')).to.be.true;
         });
 
         it('should move focus to the closest enabled element if last is disabled on "end" keydown', () => {

--- a/theme/lumo/vaadin-accordion-styles.html
+++ b/theme/lumo/vaadin-accordion-styles.html
@@ -14,10 +14,6 @@
         border-bottom: none;
       }
 
-      :host([focused]) [part="summary"] {
-        box-shadow: 0 0 0 2px var(--lumo-primary-color-50pct);
-      }
-
       :host([theme~="filled"]) {
         border-bottom: none;
       }

--- a/theme/material/vaadin-accordion-styles.html
+++ b/theme/material/vaadin-accordion-styles.html
@@ -27,10 +27,6 @@
       :host([opened]:not(:last-child)) {
         margin-bottom: 16px;
       }
-
-      :host([focused]) [part="summary"] {
-        background: var(--material-secondary-background-color);
-      }
     </style>
   </template>
 </dom-module>


### PR DESCRIPTION
Related to https://github.com/vaadin/vaadin-accordion/issues/11#issuecomment-454308278

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-accordion/19)
<!-- Reviewable:end -->
