### PR TITLE
DO NOT MERGE: replace symbols with dumb classes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,5 +4,8 @@
     "sourceType": "module",
     "ecmaVersion": 2018,
     "project": "./tsconfig.json"
+  },
+  "rules": {
+    "max-classes-per-file": "off"
   }
 }

--- a/src/roving-tabindex-mixin.ts
+++ b/src/roving-tabindex-mixin.ts
@@ -1,23 +1,31 @@
 import { LitElement } from 'lit-element';
-import { KeyboardDirectionInterface, getAvailableIndex, isFocusable, $focus } from './keyboard-direction-mixin';
-import { $itemsChanged, SlottedItemsInterface } from './slotted-items-mixin';
+import {
+  KeyboardDirectionClass,
+  KeyboardDirectionInterface,
+  getAvailableIndex,
+  isFocusable
+} from './keyboard-direction-mixin';
+import { SlottedItemsClass, SlottedItemsInterface } from './slotted-items-mixin';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Constructor<T = object> = new (...args: any[]) => T;
 
-const $setFocusable = Symbol('setFocusable');
+export abstract class RovingTabIndexClass extends LitElement {
+  protected _setFocusable?(idx: number): void;
 
-const $setTabIndex = Symbol('setTabIndex');
-
-export interface RovingTabIndexInterface {
-  [$setFocusable](idx: number): void;
-  [$setTabIndex](item: HTMLElement): void;
+  protected _setTabIndex?(item: HTMLElement): void;
 }
 
-export type RovingTabIndexConstructor = Constructor<RovingTabIndexInterface>;
+export type RovingTabIndexConstructor = Constructor<RovingTabIndexClass>;
 
 export const RovingTabIndexMixin = <
-  T extends Constructor<KeyboardDirectionInterface & SlottedItemsInterface & LitElement>
+  T extends Constructor<
+    KeyboardDirectionClass &
+      KeyboardDirectionInterface &
+      SlottedItemsClass &
+      SlottedItemsInterface &
+      RovingTabIndexClass
+  >
 >(
   base: T
 ): T & RovingTabIndexConstructor => {
@@ -29,30 +37,30 @@ export const RovingTabIndexMixin = <
       }
     }
 
-    [$itemsChanged](items: HTMLElement[], oldItems: HTMLElement[]) {
-      super[$itemsChanged](items, oldItems);
+    protected _itemsChanged(items: HTMLElement[], oldItems: HTMLElement[]) {
+      super._itemsChanged && super._itemsChanged(items, oldItems); // eslint-disable-line no-unused-expressions
 
       if (items) {
         const { focused } = this;
-        this[$setFocusable](focused && this.contains(focused) ? items.indexOf(focused as HTMLElement) : 0);
+        this._setFocusable(focused && this.contains(focused) ? items.indexOf(focused as HTMLElement) : 0);
       }
     }
 
-    [$setFocusable](idx: number) {
+    protected _setFocusable(idx: number) {
       const index = getAvailableIndex(this.items, idx, 1, isFocusable);
-      this[$setTabIndex](this.items[index]);
+      this._setTabIndex(this.items[index]);
     }
 
-    [$setTabIndex](item: HTMLElement) {
+    protected _setTabIndex(item: HTMLElement) {
       this.items.forEach((el: HTMLElement) => {
         // eslint-disable-next-line no-param-reassign
         el.tabIndex = el === item ? 0 : -1;
       });
     }
 
-    [$focus](item: HTMLElement) {
-      super[$focus](item);
-      this[$setTabIndex](item);
+    protected _focus(item: HTMLElement) {
+      super._focus && super._focus(item); // eslint-disable-line no-unused-expressions
+      this._setTabIndex(item);
     }
   }
 

--- a/src/vaadin-accordion.ts
+++ b/src/vaadin-accordion.ts
@@ -1,7 +1,7 @@
 import { html, css, customElement, property, PropertyValues } from 'lit-element';
 import { VaadinElement } from '@vaadin/element-base/vaadin-element.js';
-import { KeyboardDirectionMixin, $focus, $isPrevKey, $isNextKey, $onKeydown } from './keyboard-direction-mixin';
-import { SlottedItemsMixin, $itemsChanged, $filterItems } from './slotted-items-mixin';
+import { KeyboardDirectionMixin } from './keyboard-direction-mixin';
+import { SlottedItemsMixin } from './slotted-items-mixin';
 import { VaadinAccordionPanel } from './vaadin-accordion-panel';
 
 declare global {
@@ -85,25 +85,25 @@ export class VaadinAccordion extends KeyboardDirectionMixin(SlottedItemsMixin(Va
     }
   }
 
-  [$filterItems]() {
+  protected _filterItems() {
     return Array.from(this.querySelectorAll(VaadinAccordionPanel.is)) as VaadinAccordionPanel[];
   }
 
-  [$focus](item: VaadinAccordionPanel) {
-    super[$focus](item);
+  protected _focus(item: VaadinAccordionPanel) {
+    super._focus && super._focus(item); // eslint-disable-line no-unused-expressions
     item.setAttribute('focus-ring', '');
   }
 
-  [$isNextKey](key: string) {
+  protected _isNextKey(key: string) {
     return key === 'ArrowDown';
   }
 
-  [$isPrevKey](key: string) {
+  protected _isPrevKey(key: string) {
     return key === 'ArrowUp';
   }
 
-  [$itemsChanged](panels: VaadinAccordionPanel[], oldPanels: VaadinAccordionPanel[]) {
-    super[$itemsChanged](panels, oldPanels);
+  protected _itemsChanged(panels: VaadinAccordionPanel[], oldPanels: VaadinAccordionPanel[]) {
+    super._itemsChanged && super._itemsChanged(panels, oldPanels); // eslint-disable-line no-unused-expressions
 
     panels
       .filter(panel => !oldPanels.includes(panel))
@@ -118,11 +118,11 @@ export class VaadinAccordion extends KeyboardDirectionMixin(SlottedItemsMixin(Va
       });
   }
 
-  [$onKeydown](event: KeyboardEvent) {
+  protected _onKeydown(event: KeyboardEvent) {
     // only check keyboard events on summary, not on the content
     const summary = event.composedPath()[0] as HTMLElement;
-    if (summary && summary.getAttribute('part') === 'summary') {
-      super[$onKeydown](event);
+    if (summary && summary.getAttribute('part') === 'summary' && super._onKeydown) {
+      super._onKeydown(event);
     }
   }
 


### PR DESCRIPTION
Do not merge. This is a PR for discussion purposes only.
The `wip/next` branch has to be updated accordingly as we decide here.

## Overview

The root problem is microsoft/TypeScript#17744 that is still unsolved.
See also "Related TS issues" below for more context.

These are 3 approaches that we might use for mixins that need to have protected methods, that can be overridden by the subclass including the `super` call.

## 1. Symbol approach

- Not using `protected` methods in the mixins

- Using `Symbol` as recommended by [Elix](https://component.kitchen/blog/posts/hiding-internal-framework-methods-and-properties-from-web-component-apis) instead

### Pros

- Methods are truly protected (can't be called  from outside, e.g. by 3rd party code)

- Methods are "public" in terms of TS and can be annotated on the `interface`

- Explicit exports helping to make sure the consumers have compilation errors in case the new version was released an the internal API contracts of the protected methods have changed

- Methods are excluded from the DevTools console's auto-complete list (good for user)

- Symbols also avoid potential name conflicts if a component user wants to extend a custom element with their own methods.

### Cons

- Consumers have to import symbols if they need to override protected methods

- Jump to definition is not ideal (jumps to the place where `Symbol()` is created)

## 2. Dumb class approach

- Using `protected` methods in the mixins

- Using `abstract class SlottedItemsClass extends LitElement` to "annotate" them

### Pros

- No need to import anything (except the mixin itself) for the consumer component

- Methods are easy to access in the DevTools console (good for us as maintainers)

### Cons

- Both interface (for public API) and abstract class (for protected API) are needed

- The abstract class ends up in the JS output (as empty class with no methods)

- The mixin function needs to confusingly accept the argument with a type cast (instead of the actual expected class) in order to pick up the annotated protected methods from it: 

```ts
// with dumb class: confusing
<T extends Constructor<SlottedItemsClass>>(base: T)

// without dumb class: clean
<T extends Constructor<LitElement>>(base: T)
```

- Need for extra `super` check: `super._focus && super._focus()` - this is needed because the abstract classes mark methods using `_focus?()`, i.e. "possibly undefined"

- Methods can be only called in tests with `as any` workaround

- Jump to definition from the subclass goes to a dumb class

## 3. Public methods approach

- Keep methods `public`, add them on the `interface`

- Jump to definition works as expected

## Pros

- No extra code needed (symbols / dumb classes)

## Cons

- TS users would get protected methods listed in the code completion

- Messing up `public` and `protected` API might require tweaks for tools

## Summary

Personally, I like symbols approach more because it's cleaner, and it's not about "fighting with how TypeScrip works". But I'm ok with using the `protected` methods, too.

## Related TS issues 

- https://github.com/microsoft/TypeScript/issues/17744#issuecomment-431534647

- https://github.com/microsoft/TypeScript/issues/25163#issuecomment-507074489

- https://github.com/microsoft/TypeScript/issues/17293#issuecomment-522491710