### PR TITLE
feat: prepare for TS defs generation [skip ci]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,9 +26,9 @@
   ],
   "dependencies": {
     "polymer": "^2.0.0",
-    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.2.0",
-    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.3.0",
-    "vaadin-details": "vaadin/vaadin-details#^1.1.0",
+    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.6.1",
+    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.4.1",
+    "vaadin-details": "vaadin/vaadin-details#^1.2.0-alpha1",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.4.1",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.2.0"
   },

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,0 +1,9 @@
+{
+  "excludeFiles": [
+    "wct.conf.js",
+    "index.html",
+    "demo/**/*",
+    "test/**/*",
+    "theme/**/*"
+  ]
+}

--- a/magi-p3-post.js
+++ b/magi-p3-post.js
@@ -1,0 +1,11 @@
+module.exports = {
+  files: [
+    'vaadin-accordion.js'
+  ],
+  from: [
+    /import '\.\/theme\/lumo\/vaadin-(.+)\.js';/
+  ],
+  to: [
+    `import './theme/lumo/vaadin-$1.js';\nexport * from './src/vaadin-$1.js';`
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://vaadin.com/components",
   "files": [
+    "vaadin-*.d.ts",
     "vaadin-*.js",
     "src",
     "theme"

--- a/src/vaadin-accordion-panel.html
+++ b/src/vaadin-accordion-panel.html
@@ -35,7 +35,7 @@ This program is available under Apache License Version 2.0, available at https:/
      *
      * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
      *
-     * @memberof Vaadin
+     * @extends Vaadin.DetailsElement
      */
     class AccordionPanelElement extends Vaadin.DetailsElement {
       static get is() {

--- a/src/vaadin-accordion.html
+++ b/src/vaadin-accordion.html
@@ -89,6 +89,7 @@ This program is available under Apache License Version 2.0, available at https:/
              * The index of currently opened panel. First panel is opened by
              * default. Only one panel can be opened at the same time.
              * Setting null or undefined closes all the accordion panels.
+             * @type {number}
              */
             opened: {
               type: Number,
@@ -101,6 +102,7 @@ This program is available under Apache License Version 2.0, available at https:/
              * The list of `<vaadin-accordion-panel>` child elements.
              * It is populated from the elements passed to the light DOM,
              * and updated dynamically when adding or removing panels.
+             * @type {!Array<!AccordionPanelElement>}
              */
             items: {
               type: Array,
@@ -122,6 +124,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         /**
+         * @return {Element | null}
          * @protected
          */
         get focused() {
@@ -155,10 +158,16 @@ This program is available under Apache License Version 2.0, available at https:/
           });
         }
 
+        /**
+         * @param {!Array<!Element>} array
+         * @return {!Array<!AccordionPanelElement>}
+         * @protected
+         */
         _filterItems(array) {
           return array.filter(el => el instanceof Vaadin.AccordionPanelElement);
         }
 
+        /** @private */
         _updateItems(items, opened) {
           if (items) {
             const itemToOpen = items[opened];
@@ -168,6 +177,10 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /**
+         * @param {!KeyboardEvent} event
+         * @protected
+         */
         _onKeydown(event) {
           // only check keyboard events on details toggle buttons
           const item = event.composedPath()[0];
@@ -211,6 +224,12 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /**
+         * @param {number} index
+         * @param {number} increment
+         * @return {number}
+         * @protected
+         */
         _getAvailableIndex(index, increment) {
           const totalItems = this.items.length;
           let idx = index;
@@ -229,6 +248,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return -1;
         }
 
+        /** @private */
         _updateOpened(e) {
           const target = this._filterItems(e.composedPath())[0];
           const idx = this.items.indexOf(target);


### PR DESCRIPTION
Fixes #39 

Generated TS definition files look like this:

### `vaadin-accordion.d.ts`

```ts
import {PolymerElement} from '@polymer/polymer/polymer-element.js';

import {FlattenedNodesObserver} from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';

import {ElementMixin} from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';

import {ThemableMixin} from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

import {AccordionPanelElement} from './vaadin-accordion-panel.js';

import {html} from '@polymer/polymer/lib/utils/html-tag.js';

declare class AccordionElement extends
  ElementMixin(
  ThemableMixin(
  PolymerElement)) {
  readonly focused: Element|null;
  opened: number;
  readonly items: AccordionPanelElement[];
  ready(): void;
  focus(): void;
  _filterItems(array: Element[]): AccordionPanelElement[];
  _onKeydown(event: KeyboardEvent): void;
  _getAvailableIndex(index: number, increment: number): number;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-accordion": AccordionElement;
  }
}

export {AccordionElement};
```

### `vaadin-accordion-panel.d.ts`

```ts
import {DetailsElement} from '@vaadin/vaadin-details/src/vaadin-details.js';

declare class AccordionPanelElement extends DetailsElement {
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-accordion-panel": AccordionPanelElement;
  }
}

export {AccordionPanelElement};
```